### PR TITLE
Decompiling SpuSetReverb

### DIFF
--- a/config/symbol_addrs.slus_006.64.txt
+++ b/config/symbol_addrs.slus_006.64.txt
@@ -418,6 +418,7 @@ SpuSetIRQ = 0x8004D600;
 SpuSetIRQCallback = 0x8004D740;
 SpuSetTransferCallback = 0x8004D964;
 SpuSetCommonAttr = 0x8004D988;
+SpuSetReverbModeType = 0x8004DD1C;
 SpuClearReverbWorkArea = 0x8004E3C8;
 
 // PSY-Q Memory Card
@@ -494,6 +495,10 @@ g_SpuIRQCallback = 0x80058E44;
 g_spu_AllocBlockNum = 0x80058E64;
 g_spu_AllocLastNum = 0x80058E68;
 g_spu_memList = 0x80058E6C;
+g_SpuReverbFlag = 0x800589A8;
+g_bSpuReserveWorkArea = 0x800589AC;
+g_SpuReverbOffsetAddress = 0x800589B0;
+g_pSpuRegisters = 0x80058E08;
 
 // Main
 g_KernelErrorDescriptions = 0x8004F2C0;

--- a/src/slus_006.64/psyq/libspu.c
+++ b/src/slus_006.64/psyq/libspu.c
@@ -1,4 +1,36 @@
 #include "common.h"
+#include "psyq/libspu.h"
+
+typedef struct {
+    u32 Data1; // Volume
+    u32 Data2; // Pitch/loop
+    u32 Data3; // ADSR
+    u32 Data4; // Misc
+} VoiceData;
+
+// TODO(jperos): Fill out this big ol struct
+typedef struct {
+    VoiceData voiceData[24];
+    u8 padding[0x2A];
+    u16 controlRegister;
+} SpuRegisters;
+
+#define SPU_CONTROL_FLAG_CD_AUDIO_ENABLE    (1u <<  0)
+#define SPU_CONTROL_FLAG_EXT_AUDIO_ENABLE   (1u <<  1)
+#define SPU_CONTROL_FLAG_CD_AUDIO_REVERB    (1u <<  2)
+#define SPU_CONTROL_FLAG_EXT_AUDIO_REVERB   (1u <<  3)
+#define SPU_CONTROL_SRAM_TRANSFER_MODE      (1u <<  4) // 2 bits
+#define SPU_CONTROL_FLAG_IRQ9_ENABLE        (1u <<  6)
+#define SPU_CONTROL_FLAG_MASTER_REVERB      (1u <<  7)
+#define SPU_CONTROL_NOISE_FREQUENCY_STEP    (1u <<  8) // 2 bits
+#define SPU_CONTROL_NOISE_FREQUENCY_SHIFT   (1u << 10) // 4 bits
+#define SPU_CONTROL_FLAG_MUTE_SPU           (1u << 14)
+#define SPU_CONTROL_FLAG_SPU_ENABLE         (1u << 15)
+
+extern long g_SpuReverbFlag;
+extern long g_bSpuReserveWorkArea;
+extern long g_SpuReverbOffsetAddress;
+extern SpuRegisters* g_pSpuRegisters;
 
 INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", _spu_t);
 
@@ -28,7 +60,36 @@ INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuInitMalloc);
 
 INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", func_8004D364);
 
-INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuSetReverb);
+// INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuSetReverb);
+long SpuSetReverb (long on_off) // 100% matching on PSYQ4.0 (gcc 2.7.2 + aspsx 2.56)
+{
+    long spuControlRegister;
+
+    switch( on_off ) {
+    case SPU_OFF:
+        g_SpuReverbFlag = SPU_OFF;
+        spuControlRegister = g_pSpuRegisters->controlRegister;
+        spuControlRegister &= ~SPU_CONTROL_FLAG_MASTER_REVERB;
+        g_pSpuRegisters->controlRegister = spuControlRegister;
+        break;
+        
+    case SPU_ON:
+        if( g_bSpuReserveWorkArea != on_off && _SpuIsInAllocateArea_(g_SpuReverbOffsetAddress) ) {
+            g_SpuReverbFlag = SPU_OFF;
+            spuControlRegister = g_pSpuRegisters->controlRegister;
+            spuControlRegister &= ~SPU_CONTROL_FLAG_MASTER_REVERB;
+            g_pSpuRegisters->controlRegister = spuControlRegister;
+        } else {
+            g_SpuReverbFlag = on_off;
+            spuControlRegister = g_pSpuRegisters->controlRegister;
+            spuControlRegister |= SPU_CONTROL_FLAG_MASTER_REVERB;
+            g_pSpuRegisters->controlRegister = spuControlRegister;
+        }
+        break;
+    }
+
+    return g_SpuReverbFlag;
+}
 
 INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", func_8004D484);
 
@@ -56,7 +117,7 @@ INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuSetTransferCallback);
 
 INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuSetCommonAttr);
 
-INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", func_8004DD1C);
+INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuSetReverbModeType);
 
 INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", func_8004DEF8);
 


### PR DESCRIPTION
There are some internal globals inside of libspu - I'm not sure how you want to handle that, whether with a private header or what. For now I'm just putting those globals in the top of libspu.c.

There are a lot of other fairly known globals in here that would allow further reverse engineering of the spu library in this game.