### PR TITLE
SpuSetNoiseClock

### DIFF
--- a/src/slus_006.64/psyq/libspu.c
+++ b/src/slus_006.64/psyq/libspu.c
@@ -245,7 +245,26 @@ void SpuQuit(void) {
 
 INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuInitMalloc);
 
-INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuSetNoiseClock);
+long SpuSetNoiseClock(long n_clock) {
+    long clamped;
+    u16 controlRegister;
+    u16 newVal;
+    
+
+    if (n_clock < 0) {
+        clamped = 0;
+    } else if (n_clock > 0x3F) {  // >= 64
+        clamped = 0x3F;      // = 63
+    } else {
+        clamped = n_clock;
+    }
+    
+    controlRegister = g_pSpuRegisters->controlRegister;
+    newVal = (controlRegister & 0xC0FF) | ((clamped & 0x3F) << 8);
+    ((volatile SpuRegisters*)g_pSpuRegisters)->controlRegister = newVal;
+
+    return clamped;
+}
 
 long SpuSetReverb (long on_off) // 100% matching on PSYQ4.0 (gcc 2.7.2 + aspsx 2.56)
 {


### PR DESCRIPTION
I've still yet to determine if it makes more sense for the SpuRegisters to be volatile by default and cast to non-volatility, or vice versa. I guess this will become more clear over time as I see which case is more common.

So stoked that I have a new variable at play for combining into my rituals.