### PR TITLE
SpuSetTransferStartAddr

### DIFF
--- a/config/symbol_addrs.slus_006.64.txt
+++ b/config/symbol_addrs.slus_006.64.txt
@@ -415,6 +415,7 @@ PCwrite = 0x8004c470;
 SpuInit = 0x8004C548;
 _SpuInit = 0x8004C568;
 SpuStart = 0x8004C660;
+_spu_init = 0x8004C6DC;
 _spu_FiDMA = 0x8004CB3C;
 _spu_t = 0x8004CCA8;
 _spu_Fw = 0x8004CF38;
@@ -524,6 +525,8 @@ g_GpuCurTIMHandle = 0x8005A37C;
 // PSY-Q SPU
 g_SpuRunning = 0x80058E04;
 g_SpuEVdma = 0x8005899C;
+g_SpuTransferAddr = 0x80058E20;
+g_SpuTransferAddrShift = 0x80058E30;
 g_SpuTransferCallback = 0x80058E40;
 g_SpuIRQCallback = 0x80058E44;
 g_spu_AllocBlockNum = 0x80058E64;

--- a/src/slus_006.64/psyq/libspu.c
+++ b/src/slus_006.64/psyq/libspu.c
@@ -162,6 +162,8 @@ typedef struct {
 
 extern long g_SpuRunning;
 extern long g_SpuEVdma;
+extern short g_SpuTransferAddr;
+extern long g_SpuTransferAddrShift;
 extern volatile SpuIRQCallbackProc g_SpuIRQCallback;
 extern volatile SpuTransferCallbackProc g_SpuTransferCallback;
 extern long g_SpuTransferMode;
@@ -200,7 +202,7 @@ void SpuStart(void) {
     }
 }
 
-INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", func_8004C6DC);
+INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", _spu_init);
 
 INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", func_8004C970);
 
@@ -337,7 +339,19 @@ INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuRead);
 // Possible SpuWrite
 INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", func_8004D878);
 
-INCLUDE_ASM("asm/slus_006.64/nonmatchings/psyq/libspu", SpuSetTransferStartAddr);
+u_long SpuSetTransferStartAddr(u_long addr) {
+    u32 offset;
+    u16 base_addr;
+
+    offset = addr - 0x1010;
+    if (offset > 0x7efe8) {
+        return 0;
+    }
+
+    base_addr = _spu_FsetRXXa(-1, addr);
+    g_SpuTransferAddr = base_addr;
+    return (ulong)base_addr << g_SpuTransferAddrShift;
+}
 
 long SpuSetTransferMode(long mode) {
     int value;

--- a/src/slus_006.64/psyq/libspu.c
+++ b/src/slus_006.64/psyq/libspu.c
@@ -148,6 +148,11 @@ typedef struct {
     ReverbRegisters m_Regs;
 } ReverbPreset;
 
+#define SPU_MIN_ADDR 0x1010
+#define SPU_MAX_SIZE 512 * 1024
+#define SPU_MAX_ALIGNED_ADDR (SPU_MAX_SIZE - 8) // 0x7fff8 - largest 8-byte aligned addr < 512KB
+#define SPU_MAX_VALID_OFFSET (SPU_MAX_ALIGNED_ADDR - SPU_MIN_ADDR)  // 0x7efe8
+
 #define SPU_CONTROL_FLAG_CD_AUDIO_ENABLE    (1u <<  0)
 #define SPU_CONTROL_FLAG_EXT_AUDIO_ENABLE   (1u <<  1)
 #define SPU_CONTROL_FLAG_CD_AUDIO_REVERB    (1u <<  2)
@@ -343,8 +348,8 @@ u_long SpuSetTransferStartAddr(u_long addr) {
     u32 offset;
     u16 base_addr;
 
-    offset = addr - 0x1010;
-    if (offset > 0x7efe8) {
+    offset = addr - SPU_MIN_ADDR;
+    if (offset > SPU_MAX_VALID_OFFSET) {
         return 0;
     }
 


### PR DESCRIPTION
Some globals in here identified as bit shifted addresses that are used all across all of the spu transfer functions that encompass the first quarter or so of the libspu code