### PR TITLE
Leverage docker to run builds on non-Linux/x86_64 platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:latest
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update; apt install -y git make binutils-mips-linux-gnu cpp-mips-linux-gnu python3 python3-pip python3-venv
+
+COPY requirements.txt /tmp/requirements.txt
+RUN python3 -m venv /.venv && . /.venv/bin/activate && python3 -m pip install -r /tmp/requirements.txt
+# NB: Don't rename this. Gears depends on this to figure out where the project files
+# are located. See find_base_path() in tools/gears/src/file_system.rs
+WORKDIR /xenogears-decomp

--- a/Makefile
+++ b/Makefile
@@ -4,25 +4,75 @@ CONFIG_DIR   := config
 TOOLS_DIR    := tools
 OBJDIFF_DIR  := $(TOOLS_DIR)/objdiff
 EXPECTED_DIR := expected
+DOCKERFILE   := ./Dockerfile
+DOCKER       := $(shell sh -c 'command -v docker || true')
+OBJDIFF      := $(OBJDIFF_DIR)/objdiff
+PYTHON       := python3
+
+# Detect host OS and architecture
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 
 # Tools
-GEARS   := $(TOOLS_DIR)/gears/prebuilt/gears
-OBJDIFF := $(OBJDIFF_DIR)/objdiff
-PYTHON  := python3
+# The binary tools in this repo require linux/x86_64 -- if we're on that platform,
+# use prebuild Gears and do build directly on the host
+ifeq ($(uname_S)-$(uname_M),Linux-x86_64)
+	GEARS        := $(TOOLS_DIR)/gears/prebuilt/gears
+	NEED_DOCKER := false
+	NEED_GEARS := false
+else
+	# Use the compiled version of Gears
+	GEARS        := $(TOOLS_DIR)/gears/target/release/gears
+	# flag used below to run build in a docker container
+	NEED_DOCKER := true
+	# flag used below to trigger gears build automatically
+	NEED_GEARS := true
+endif
 
 # Settings
-NUMPROC ?= $(shell nproc)
+ifeq ($(uname_S),Linux)
+	NUMPROC ?= $(shell nproc)
+endif
+ifeq ($(uname_S),Darwin)
+	NUMPROC ?= $(shell sysctl -n hw.logicalcpu)
+endif
 
 # Rules
 default: all
 
 all: build
 
+ifeq ($(NEED_GEARS),true)
+# add make targets to build Gears, and add dependencies.
+$(GEARS):
+	cd $(TOOLS_DIR)/gears && cargo build --release
+
+ifneq ($(NEED_DOCKER), true)
+build: $(GEARS)
+endif
+clean: $(GEARS)
+endif
+
+ifeq ($(NEED_DOCKER),true)
+# provide a useful error for non-linux/x86_64 platforms
+ifeq (,$(DOCKER))
+$(error Docker is required for platform $(uname_S)/$(uname_M))
+endif
+
+# make target to build the container
+docker:
+	docker buildx build --platform linux/amd64 . -t ethos:latest --quiet
+# build target runs build in the container. note that files get written to the
+# host filesystem, not the container filesystem.
+build: docker
+	docker run --rm -it --platform=linux/amd64 -v$(PWD):/xenogears-decomp ethos:latest /bin/bash -c '. /.venv/bin/activate && make build'
+else
 build:
 	$(MAKE) clean; \
 	$(GEARS) matching; \
 	ninja -t clean; \
 	ninja -j$(NUMPROC)
+endif
 
 check: clean build
 	@sha256sum --ignore-missing --check $(CONFIG_DIR)/checksum.sha


### PR DESCRIPTION
I'm on an apple silicon mac, so I can't run the linux binaries directly.

What this commit does:
- define a Dockerfile that will build a container pre-configured with all of the build requirements
- update the Makefile to automatically detect the host OS/arch and, when not Linux/x86_64, run the build in a container instead of directly on the host