### PR TITLE
match FieldScriptVMRun

### DIFF
--- a/include/field/actor.h
+++ b/include/field/actor.h
@@ -325,8 +325,8 @@ typedef struct {
     /* 0x2C */ MATRIX childMatrix;
     /* 0x4C */ ActorData* pActorData;
     /* 0x50 */ SVEC rotation;
-    short flags;
-    short status;
+    /* 0x56 */ short flags;
+    /* 0x58 */ short status;
 } FieldActor;
 
 typedef struct {

--- a/include/field/script_vm.h
+++ b/include/field/script_vm.h
@@ -22,12 +22,19 @@
 #define SCRIPT_VAR_SYSTEM_TIME_LOW 0xC // Seconds and minutes
 #define SCRIPT_VAR_SYSTEM_TIME_HIGH 0xE // Hours
 
+typedef void (*ScriptVMHandler)(void);
+
 // Is Yielding maybe?
 extern int D_800B00C0;
+extern char D_8006FD84;
+extern int D_800ADBE0;
+extern int D_800ADBE4;
+extern int D_800ADBEC;
+extern int D_800ADB1C;
 
 extern int FieldScriptVMGetInstructionArgument(int);
 extern int FieldScriptVMGetVariableSign(int);
 extern int FieldScriptVMGetVariableValue(int);
 extern short FieldScriptVMGetInstructionArgumentS16(int);
-
+extern ScriptVMHandler g_FieldScriptVMHandlers[];
 #endif

--- a/include/field/text_box.h
+++ b/include/field/text_box.h
@@ -14,6 +14,7 @@ typedef struct {
     SPRT sprites[2];
 } FieldTextBoxCursor;
 
+/* size = 0x44 */
 typedef struct {
     short visibility;
     u_char _pad[2];
@@ -43,24 +44,23 @@ typedef struct {
 
 // FieldTextBox Size 0x498
 typedef struct {
-    DR_MODE drawModes[2];
+    /* 0x000 */ DR_MODE drawModes[2];
 
-    // 0x18
-    short _pad[0x56];
+    /* 0x018 */ short _pad[0x56];
 
-    // Background, 0xC4
-    FieldTextBoxBackground background;
+    // Background
+    /* 0x0C4 */FieldTextBoxBackground background;
 
-    // Borders, 0xFC
-    FieldTextBoxBorders borders;
+    // Borders
+    /* 0x0FC */ FieldTextBoxBorders borders;
 
-    // Cursor, 0x37C
-    FieldTextBoxCursor cursor;
+    // Cursor
+    /* 0x37C */ FieldTextBoxCursor cursor;
 
-    // Continue Arrow, 0x3C4
-    FieldTextBoxContinueArrow continueArrow;
-    short windowOpenTimer;
-    short continueArrowTimer;
+    // Continue Arrow
+    /* 0x3C4 */ FieldTextBoxContinueArrow continueArrow;
+    /* 0x408 */ short windowOpenTimer;
+    /* 0x40A */ short continueArrowTimer;
 
     /*
     0x0001 - set when top message init and bottom.
@@ -68,20 +68,20 @@ typedef struct {
     0x0040 - don't render border and background and continue arrow.
     0x0080 - set when bottom message init.
     */
-    short flags; // 0x40C
-    short visibility; // 0 = Visible, -1 = Hidden
-    u_short order; // 0-top. 0xffff if window not inited
-    short unk412;
-    short status; // Set to 0 to close window. Usually 0xffff (not used in usual window render)
-    short ownerActorID;
-    short talkingActorID;
-    int positionOffsetX;
-    int positionOffsetY;
-    int positionOffsetDeltaX;
-    int positionOffsetDeltaY;
+    /* 0x40C */ short flags;
+    /* 0x40E */ short visibility; // 0 = Visible, -1 = Hidden
+    /* 0x410 */ u_short order; // 0-top. 0xffff if window not inited
+    /* 0x412 */ short unk412;
+    /* 0x414 */ short status; // Set to 0 to close window. Usually 0xffff (not used in usual window render)
+    /* 0x416 */ short ownerActorID;
+    /* 0x418 */ short talkingActorID;
+    /* 0x41C */ int positionOffsetX;
+    /* 0x420 */ int positionOffsetY;
+    /* 0x424 */ int positionOffsetDeltaX;
+    /* 0x428 */ int positionOffsetDeltaY;
 
-    // Portrait, 0x42C
-    FieldTextBoxPortrait portrait;
+    // Portrait
+    /* 0x42C */ FieldTextBoxPortrait portrait;
 } FieldTextBox;
 
 extern FieldTextBox g_FieldTextBoxes[4];

--- a/include/system/debug.h
+++ b/include/system/debug.h
@@ -3,4 +3,12 @@
 
 #define POSSIBLE_DEBUG_CODE if(0){while(1);}
 
+#ifdef WANT_BREAKPOINTS
+#define ASM_BREAKPOINT "break"
+#else
+#define ASM_BREAKPOINT ""
+#endif
+
+#define SYSTEM_PC_HARDDRIVE 0
+
 #endif

--- a/src/field/scripts/virtual_machine.c
+++ b/src/field/scripts/virtual_machine.c
@@ -6,6 +6,7 @@
 #include "field/effects.h"
 #include "system/memory.h"
 #include "system/archive.h"
+#include "system/debug.h"
 #include "psyq/libgpu.h"
 #include "psyq/libcd.h"
 
@@ -211,7 +212,50 @@ void func_800A1E9C(void) {
     g_FieldScriptVMCurActor->scriptInstructionPointer++;
 }
 
-INCLUDE_ASM("asm/field/nonmatchings/scripts/virtual_machine", FieldScriptVMRun);
+void FieldScriptVMRun(int maxInstructionCount) {
+    int nInstructionCount;
+    u_short nInstructionPointer;
+    u_char nHandlerIndex;
+
+    D_800B00C0 = 0;
+    g_FieldScriptMaxInstructionCount = maxInstructionCount;
+
+    for (nInstructionCount = 0; nInstructionCount < g_FieldScriptMaxInstructionCount; nInstructionCount++) {
+        /* TODO: delete this asm() when we hit 100% matching.
+         *
+         * The current working theory is that there was some debugging code injected here, most likely a break
+         * instruction, and they just changed the define to an empty string for the release build. This caused
+         * the loop optimization for this function to break, which is why you see a noop in the jump's delay
+         * slot. From all testing done with code structure and compiler arguments, this appears to be the only
+         * way to make the function match.
+         */
+        asm(ASM_BREAKPOINT);
+        if (nInstructionCount > 0x400) {
+            if (g_FieldSystemMode == SYSTEM_PC_HARDDRIVE) {
+                func_800379C8(&D_8006FD84, D_800AFD1C); // Error printing
+            }
+            return;
+        }
+        nInstructionPointer = g_FieldScriptVMCurActor->scriptInstructionPointer;
+        nHandlerIndex = ((u_char *)g_FieldScriptVMCurScriptData)[nInstructionPointer];
+        g_FieldScriptVMHandlers[nHandlerIndex]();
+
+        if (D_800AFFEC == 0) {
+            g_FieldScriptMaxInstructionCount = 0xFFFF;
+        }
+
+        // Various exit checks
+        if ((D_800ADB1C != 0 && (D_800ADBE0 == 0 ||  D_800ADBE4 == 0 ||  D_800ADBEC == 0))) {
+            return;
+        }
+
+        if (D_800B00C0 == 1 && D_800AFFEC == D_800B00C0) {
+            return;
+        }
+
+    }
+
+}
 
 INCLUDE_ASM("asm/field/nonmatchings/scripts/virtual_machine", func_800A2030);
 
@@ -371,4 +415,3 @@ void func_800A476C(int x, int y) {
     MoveImage(&rect, x, y);
     FieldRenderSync();
 }
-


### PR DESCRIPTION
This function has been mostly-matched for awhile; the issue has been a quirk where the for loop in the original game appears to be unoptimized, and no way of constructing the loop in C code gets the compiler to emit the same code. In order to defeat the loop optimization, we have to use an `asm("");` statement at the top of the loop.

What I have done is proposed a plausible, and I feel likely, explanation for this code: a compiled-in breakpoint controlled by an ifdef, which was set to an empty string for the release build.

A mini example of what I mean:

```c
/* in a header somewhere */
#ifdef VMSCRIPT_DEBUG
#define VMSCRIPT_BREAKPOINT "break"
#else
#define VMSCRIPT_BREAKPOINT ""
#endif

/* then the loop code looks like */
for(i = 0; i < 4; i++) {
  asm(VMSCRIPT_BREAKPOINT);
  /* other code goes here */
}
```

This PR also includes some inline documentation for a couple objects to put the offsets in a place that's easier to read/lookup.