### PR TITLE
match FieldScriptVM2Run (nee func_800869B8)

### DIFF
--- a/config/symbol_addrs.field.txt
+++ b/config/symbol_addrs.field.txt
@@ -261,6 +261,7 @@ FieldScriptPartyMemberDisembarkGear = 0x8009FCAC;
 FieldScriptVMHandlerConditionalJmp = 0x800A1BD0;
 FieldScriptVMHandlerJmp = 0x800A1E74;
 FieldScriptVMRun = 0x800A1EC8;
+FieldScriptVM2Run = 0x800869B8;
 FieldScriptVMHandlerNop = 0x800A2FC0;
 FieldScriptVMGetVariableSign = 0x800A2FE0;
 
@@ -326,7 +327,8 @@ g_pFieldTriggerZones = 0x800ADBF4;
 
 g_FieldCurScriptFile = 0x800ADBF8;
 
-g_FieldScriptVMHandlers = 0x800AE2A0;
+g_FieldScriptVMHandlers = 0x800AE2A0; // type:VoidCallback_t[] size:0x400
+g_FieldScriptVMHandlers2 = 0x800AE6A0; // type:VoidCallback_t[] size:0x38C
 
 g_FieldNumPartyMembersMasks = 0x800AEA2C;
 

--- a/include/field/actor.h
+++ b/include/field/actor.h
@@ -206,25 +206,30 @@ typedef struct {
     /* 0x124 */ SpriteDirectionTransforms directionTransforms;
 } SpriteData;
 
-typedef struct {
-    // TODO: Fix the horrible naming of these bitfields.
+// TODO: Fix the horrible naming of these bitfields.
+typedef union {
+    u_int flags;
+    struct {
+        u_int scriptFlags_0x0: 1; // isDisabled?
+        u_int scriptFlags_0x1: 7;
+        u_int scriptFlags_0x8: 1;
+        u_int type: 7;
+        u_int scriptFlags_0xX: 1;
+        u_int scriptFlags_0xA: 1; // isDialogActivationDisabled?
+        u_int scriptFlags_0x10: 1;
+        u_int scriptFlags_0x11: 1;
+        u_int scriptFlags_0x13: 1;
+        u_int scriptFlags_0x14: 1;
+        u_int scriptFlags_0x15: 1;
+        u_int scriptFlags_0x16: 1;
+        u_int scriptFlags_0x17: 1;
+        u_int scriptFlags_0x18: 1;
+        u_int scriptFlags_0x19: 6;
+    } fields;
+} ActorScriptFlags;
 
-    // MFlag
-    /* 0x0 */ u_int scriptFlags_0x0: 1; // isDisabled?
-    u_int scriptFlags_0x1: 7;
-    u_int scriptFlags_0x8: 1;
-    u_int type: 7;
-    u_int scriptFlags_0xX: 1;
-    u_int scriptFlags_0xA: 1; // isDialogActivationDisabled?
-    u_int scriptFlags_0x10: 1;
-    u_int scriptFlags_0x11: 1;
-    u_int scriptFlags_0x13: 1;
-    u_int scriptFlags_0x14: 1;
-    u_int scriptFlags_0x15: 1;
-    u_int scriptFlags_0x16: 1;
-    u_int scriptFlags_0x17: 1;
-    u_int scriptFlags_0x18: 1;
-    u_int scriptFlags_0x19: 6;
+typedef struct {
+    /* 0x0 */ ActorScriptFlags scriptFlags;
 
     // MFlag2
     u_int flags;

--- a/include/field/script_vm.h
+++ b/include/field/script_vm.h
@@ -37,4 +37,5 @@ extern int FieldScriptVMGetVariableSign(int);
 extern int FieldScriptVMGetVariableValue(int);
 extern short FieldScriptVMGetInstructionArgumentS16(int);
 extern ScriptVMHandler g_FieldScriptVMHandlers[];
+extern ScriptVMHandler g_FieldScriptVMHandlers2[];
 #endif

--- a/src/field/main/misc11.c
+++ b/src/field/main/misc11.c
@@ -253,7 +253,7 @@ void func_80093D48(void) {
 
 // The two functions seems to be related to handling room transitions
 void func_80093E30(void) {
-    if (!g_FieldScriptVMCurActor->scriptFlags_0x13) {
+    if (!g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x13) {
         if (!(g_FieldScriptVMCurActor->flags12C_0x5)) {
             g_FieldScriptVMCurActor->flags12C_0x5 = 1;
             g_FieldScriptVMCurActor->curDoorStep = 0;
@@ -267,7 +267,7 @@ void func_80093E30(void) {
                     g_FieldActors[D_800AFD1C].rotation.y -= 0x20;
                 }
             } else {
-                g_FieldScriptVMCurActor->scriptFlags_0x13 = 0x1;
+                g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x13 = 0x1;
                 g_FieldScriptVMCurActor->flags12C_0x5 = 0;
                 g_FieldScriptVMCurActor->curDoorStep = 0;
                 g_FieldScriptVMCurActor->scriptInstructionPointer += 2;
@@ -281,7 +281,7 @@ void func_80093E30(void) {
 }
 
 void func_80093FC0(void) {
-    if (g_FieldScriptVMCurActor->scriptFlags_0x13) {
+    if (g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x13) {
         if (!(g_FieldScriptVMCurActor->flags12C_0x5)) {
             g_FieldScriptVMCurActor->flags12C_0x5 = 1;
             g_FieldScriptVMCurActor->curDoorStep = 0;
@@ -295,7 +295,7 @@ void func_80093FC0(void) {
                     g_FieldActors[D_800AFD1C].rotation.y += 0x20;
                 }
             } else {
-                g_FieldScriptVMCurActor->scriptFlags_0x13 = 0;
+                g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x13 = 0;
                 g_FieldScriptVMCurActor->flags12C_0x5 = 0;
                 g_FieldScriptVMCurActor->curDoorStep = 0;
                 g_FieldScriptVMCurActor->scriptInstructionPointer += 2;
@@ -317,7 +317,7 @@ void func_80094158() {
     int angle;
     int delta;
 
-    if (!g_FieldScriptVMCurActor->scriptFlags_0x13) {
+    if (!g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x13) {
         if (!g_FieldScriptVMCurActor->flags12C_0x5) {
             g_FieldScriptVMCurActor->flags12C_0x5 = 0x1;
             g_FieldScriptVMCurActor->curDoorStep = 0;
@@ -347,7 +347,7 @@ void func_80094158() {
                         break;
                 }
             } else {
-                g_FieldScriptVMCurActor->scriptFlags_0x13 = 1;
+                g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x13 = 1;
                 g_FieldScriptVMCurActor->flags12C_0x5 = 0;
                 g_FieldScriptVMCurActor->curDoorStep = 0;   
                 g_FieldScriptVMCurActor->scriptInstructionPointer += 7;
@@ -364,7 +364,7 @@ void func_800943AC(void) {
     int angle;
     int delta;
     
-    if (g_FieldScriptVMCurActor->scriptFlags_0x13) {
+    if (g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x13) {
         if (!g_FieldScriptVMCurActor->flags12C_0x5) {
             g_FieldScriptVMCurActor->flags12C_0x5 = 0x1;
             g_FieldScriptVMCurActor->curDoorStep = 0x0;
@@ -391,7 +391,7 @@ void func_800943AC(void) {
                         break;
                 }
             } else {
-                g_FieldScriptVMCurActor->scriptFlags_0x13 = 0x0;
+                g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x13 = 0x0;
                 g_FieldScriptVMCurActor->flags12C_0x5 = 0x0;
                 g_FieldScriptVMCurActor->curDoorStep = 0;
                 g_FieldScriptVMCurActor->scriptInstructionPointer += 7;

--- a/src/field/main/misc6.c
+++ b/src/field/main/misc6.c
@@ -10,22 +10,22 @@ extern void func_800A0C94();
 extern s32 D_800AFD1C; // Current actor index
 
 void FieldScriptVMHandlerDisableDialogActivation(void) {
-    g_FieldScriptVMCurActor->scriptFlags_0xA = 0x1;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0xA = 0x1;
     g_FieldScriptVMCurActor->scriptInstructionPointer++;
 }
 
 void FieldScriptVMHandlerEnableDialogActivation(void) {
-    g_FieldScriptVMCurActor->scriptFlags_0xA = 0x0;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0xA = 0x0;
     g_FieldScriptVMCurActor->scriptInstructionPointer++;
 }
 
 void func_8009DA70(void) {
-    g_FieldScriptVMCurActor->scriptFlags_0x16 = 0x1;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x16 = 0x1;
     g_FieldScriptVMCurActor->scriptInstructionPointer++;
 }
 
 void func_8009DA98(void) {
-    g_FieldScriptVMCurActor->scriptFlags_0x16 = 0;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x16 = 0;
     g_FieldScriptVMCurActor->scriptInstructionPointer++;
 }
 
@@ -36,7 +36,7 @@ void func_8009DAC4(void) {
 
     if (FieldScriptVMGetActorIndex(1) != ACTOR_ID_INVALID) {
         pActor = g_FieldActors[FieldScriptVMGetActorIndex(1)].pActorData;
-        pActor->scriptFlags_0x0 = 0x1;
+        pActor->scriptFlags.fields.scriptFlags_0x0 = 0x1;
         pActor->flags |= 0x100000;
         pFieldActor = &g_FieldActors[FieldScriptVMGetActorIndex(1)];
         pFieldActor->status |= ACTOR_STATUS_INVISIBLE;
@@ -52,7 +52,7 @@ void FieldScriptVMHandlerEnableActorVM(void) {
 
     if (FieldScriptVMGetActorIndex(1) != ACTOR_ID_INVALID) {
         pActor = g_FieldActors[FieldScriptVMGetActorIndex(1)].pActorData;
-        pActor->scriptFlags_0x0 = 0;
+        pActor->scriptFlags.fields.scriptFlags_0x0 = 0;
     }
     g_FieldScriptVMCurActor->scriptInstructionPointer += 2;
 }
@@ -70,7 +70,7 @@ void func_8009DC4C(void) {
         pActor->move.vx = 0;
         pActor->move.vy = 0;
         pActor->move.vz = 0;
-        pActor->scriptFlags_0x0 = 1;
+        pActor->scriptFlags.fields.scriptFlags_0x0 = 1;
         nNewRotation = pActor->rotation.vx | 0x8000;
         pActor->rotation.vy = nNewRotation;
         pActor->rotation.vx = nNewRotation;
@@ -202,8 +202,8 @@ void func_8009E1A0(void) {
 
 void func_8009E208(void) {
     g_FieldScriptVMCurActor->unkEC = 0;
-    g_FieldScriptVMCurActor->scriptFlags_0x10 = 0x0;
-    g_FieldScriptVMCurActor->scriptFlags_0x15 = 0x1;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x10 = 0x0;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x15 = 0x1;
     g_FieldScriptVMCurActor->scriptInstructionPointer++;
     g_FieldScriptVMCurActor->curYPos = CONV_TO_GTE(g_FieldScriptVMCurActor->position.vy);
 }
@@ -214,13 +214,13 @@ void func_8009E248(void) {
         FieldScriptVMGetInstructionArgumentS16(3)
     );
     func_8009E810(FieldScriptVMGetInstructionArgumentS16(5));
-    g_FieldScriptVMCurActor->scriptFlags_0x10 = 0x1;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x10 = 0x1;
     g_FieldScriptVMCurActor->scriptInstructionPointer += 7;
 }
 
 void func_8009E2C8(void) {
     func_8009E810(FieldScriptArgument1(1, SCRIPT_READ_U8_REL(3)));
-    g_FieldScriptVMCurActor->scriptFlags_0x10 = 0x1;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x10 = 0x1;
     g_FieldScriptVMCurActor->scriptInstructionPointer += 4;
 }
 
@@ -236,7 +236,7 @@ void func_8009E35C(void) {
         FieldScriptArgument2(3, SCRIPT_READ_U8_REL(6))
     );
     g_FieldScriptVMCurActor->flags &= ~0x200000;
-    g_FieldScriptVMCurActor->scriptFlags_0xX = 0x0;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0xX = 0x0;
     g_FieldScriptVMCurActor->scriptInstructionPointer += 7;
 }
 
@@ -258,7 +258,7 @@ void func_8009E4BC(void) {
         FieldScriptArgument2(3, SCRIPT_READ_U8_REL(5))
     );
     g_FieldScriptVMCurActor->flags &= ~0x200000;
-    g_FieldScriptVMCurActor->scriptFlags_0xX = 0x0;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0xX = 0x0;
     g_FieldScriptVMCurActor->scriptInstructionPointer += 6;
 }
 
@@ -667,7 +667,7 @@ INCLUDE_ASM("asm/field/nonmatchings/main/misc6", func_800A0C94);
 void func_800A0D3C(void) {
     func_80076AC0(D_800AFD1C, 0, (void*)((*(s32*)(g_FieldSpriteData + 4)) + (s32)g_FieldSpriteData), 0, 0, 0x80, 1);
     func_800A0C94();
-    g_FieldScriptVMCurActor->scriptFlags_0x8 = 0x1;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x8 = 0x1;
     g_FieldScriptVMCurActor->flags |= 0x800;
     g_FieldScriptVMCurActor->scriptInstructionPointer++;
 }

--- a/src/field/main/misc7.c
+++ b/src/field/main/misc7.c
@@ -127,7 +127,7 @@ void func_80098CAC(s32 arg0) {
     }
     
     animationId = 1;
-    g_FieldScriptVMCurActor->scriptFlags_0xX = 1;
+    g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0xX = 1;
     if (SCRIPT_READ_U8_REL(1) == 0) {
         scriptArg1 = CONV_FROM_GTE(FieldScriptArgument1(2, SCRIPT_READ_U8_REL(0x8)));
         scriptArg2 = CONV_FROM_GTE(FieldScriptArgument2(4, SCRIPT_READ_U8_REL(0x8)));
@@ -201,7 +201,7 @@ void func_80098CAC(s32 arg0) {
     }
     
     if (g_FieldScriptVMCurActor->curAnimationId != animationId &&  
-        !g_FieldScriptVMCurActor->scriptFlags_0x18
+        !g_FieldScriptVMCurActor->scriptFlags.fields.scriptFlags_0x18
     ) {
         g_FieldScriptVMCurActor->curAnimationId = animationId;
         func_800821F4(pSprite, animationId, D_800B06B8, g_FieldScriptVMCurActor);

--- a/src/field/main/misc8.c
+++ b/src/field/main/misc8.c
@@ -3,6 +3,7 @@
 #include "field/main.h"
 #include "field/text_box.h"
 #include "field/effects.h"
+#include "field/script_vm.h"
 #include "system/memory.h"
 #include "system/archive.h"
 #include "system/sound.h"
@@ -198,17 +199,13 @@ void func_80086908(void) {
 }
 */
 
-// Call function from second handler table
-INCLUDE_ASM("asm/field/nonmatchings/main/misc8", func_800869B8);
-/*
-void func_800869B8(void) {
-    u_short handlerIndex;
+void FieldScriptVM2Run(void) {
+    char *script = (char *)g_FieldScriptVMCurScriptData;
+    size_t vmIP = ++(g_FieldScriptVMCurActor->scriptInstructionPointer);
 
-    handlerIndex = g_FieldScriptVMCurActor->scriptInstructionPointer + 1;
-    g_FieldScriptVMCurActor->scriptInstructionPointer = handlerIndex;
-    &gEventHandlers2[g_FieldScriptVMCurScriptData + handlerIndex]();
+    ScriptVMHandler *handler = &g_FieldScriptVMHandlers2[script[vmIP]];
+    (*handler)();
 }
-*/
 
 INCLUDE_ASM("asm/field/nonmatchings/main/misc8", func_80086A1C);
 


### PR DESCRIPTION
- renamed D_800AE6A0 => g_FieldScriptVMHandlers2
- renamed func_800869B8 => FieldScriptVM2Run
- matched FieldScriptVM2Run()

I spent some time looking over the two lookup tables to see what distinguished them, and realized the answer was "nothing" -- the reason there's a second lookup table is because the lookup index is an 8-bit value, and `g_FieldScriptVMHandlers` was full (256 entries). So, the remaining scripting functions are in
g_FieldScriptVMHandlers2, which has 227 entries.

I also refactored the actor flags into a union, because a different function I was analyzing was setting all the flags at once and that provided a clean interface to do so.