### PR TITLE
match 0x8001BEEC

### DIFF
--- a/config/symbol_addrs.slus_006.64.txt
+++ b/config/symbol_addrs.slus_006.64.txt
@@ -29,6 +29,7 @@ GamePartySyncStreamedData = 0x8001B3A8;
 // Menu
 MenuInitializeGfxEnvironment = 0x8001BDDC;
 MenuInitializeGfxEnvironments = 0x8001BE14;
+func_8001BEEC = 0x8001BEEC;
 MenuProcessControllerInput = 0x8001BF38;
 MenuExecute = 0x8001C1A8;
 MenuMain = 0x8001C634;

--- a/include/system/menu.h
+++ b/include/system/menu.h
@@ -344,12 +344,23 @@ typedef struct {
     /* 0x1D8  */ SVECTOR rotation;
     /* 0x1E0  */ VECTOR translation;
     /* 0x1F0  */ MATRIX matTransform;
-    /* 0x210  */ u8 unk1D8[0xC8];
+    /* 0x210  */ u8 unk1D8[0x8];
+    // Note: The next 8 bytes (4 shorts) could be a SVECTOR
+    /* 0x218  */ undefined16 unk218;
+    /* 0x21A  */ undefined16 unk21A;
+    /* 0x21C  */ undefined16 unk21C;
+    /* 0x21E  */ u8 unk21E[0x2];
+    // Note: the next 16 bytes (4 longs) could be a VECTOR
+    /* 0x220  */ undefined32 unk220;
+    /* 0x224  */ undefined32 unk224;
+    /* 0x228  */ undefined32 unk228;
+    /* 0x22D  */ u8 unk22D[0xAB];
     /* 0x2D8  */ u32 unk2D8;
     /* 0x2DC  */ void* unk2DC; // Resources / Textured polys
     /* 0x2E0  */ void* unk2E0; // Pointer to resources (bin 3)
     /* 0x2E4  */ SoundFile* unk2E4; // Pointer to SEDS file
-    /* 0x2E8  */ u8 unk2E8[0x20];
+    /* 0x2E8  */ undefined32 unk2E8;
+    /* 0x2EC  */ u8 unk2EC[0x1C];
     /* 0x308  */ int renderContext;
     /* 0x30C  */ u_char availableCharacters[0x10];
     /* 0x31C  */ u_char digits[0x9]; // Buffer for numbers parsed into a string

--- a/src/slus_006.64/system/menu.c
+++ b/src/slus_006.64/system/menu.c
@@ -27,7 +27,22 @@ void MenuInitializeGfxEnvironments(void) {
     MenuInitializeGfxEnvironment(&g_Menu->gfxEnvs[1]);
 }
 
-INCLUDE_ASM("asm/slus_006.64/nonmatchings/system/menu", func_8001BEEC);
+void func_8001BEEC(void) {
+    g_Menu->translation.vz = 0x800;
+    g_Menu->unk228 = 0x800;
+    g_Menu->rotation.vz = 0;
+    g_Menu->rotation.vy = 0;
+    g_Menu->rotation.vx = 0;
+    g_Menu->translation.vy = 0;
+    g_Menu->translation.vx = 0;
+    g_Menu->unk21C = 0;
+    g_Menu->unk21A = 0;
+    g_Menu->unk218 = 0;
+    g_Menu->unk224 = 0;
+    g_Menu->unk220 = 0;
+    g_Menu->unk2E8 = 1;
+    g_Menu->transitionEffectState = 0;
+}
 
 void MenuProcessControllerInput(void) {
     u_char input = MENU_INPUT_IDLE;


### PR DESCRIPTION
The code here seemed to suggest that there was another translation and another rotation within the system menu.

The code might be resetting the menu into view?

Should the type of `unk2E8` be `u32` or something else? All I know so far is that it needs to generate a `sw` when stored into, I'm not seeing much other use of the field to help disambiguate...